### PR TITLE
Fix issue with Distance text accessing invalid memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# IDE Files
+.vscode/
+
+# emscripten-generated files
+index.data
+index.html
+index.js
+index.wasm
+

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ winObjCompile:
 	${CC} ./src/*.cpp ${CFLAGSO} -mwindows
 	# laymans way to move object files to make/build folder 
 	mv *.o ./make/build
+
+web:
+	em++ -std=c++14 -Wall src/main.cpp src/entity.cpp src/renderwindow.cpp src/player.cpp src/ground.cpp src/groundtile.cpp -I include -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s SDL2_IMAGE_FORMATS=\['png'\] -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2 --preload-file res -o index.html
+

--- a/README.md
+++ b/README.md
@@ -23,12 +23,24 @@ After installing the dev packages of SDL2 for your distribution, execute the fol
 g++ -c src/*.cpp -std=c++14 -O3 -Wall -m64 -I include && mkdir -p bin/release && g++ *.o -o bin/release/main -s -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer
 ```
 The compiled binary ``main`` is located in ``./bin``. For it to run, you must copy the ``./res`` folder to its directory.
+
 ### Web
 Install [emscripten](https://emscripten.org/docs/getting_started/downloads.html) and execute the following command in the project's root directory:
 ```
 emcc src/main.cpp src/entity.cpp src/renderwindow.cpp src/player.cpp src/ground.cpp src/groundtile.cpp -I include -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s \"SDL2_IMAGE_FORMATS=['png']\" -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2 --preload-file res -o index.html
 ```
+
+You can also just run `make web` to achieve the same compilation.
+
 The compiled ``.js``, ``.wasm``, ``.data``, and ``.html`` files are located in the project's root.
+
+You can use `python` to run a server on localhost port 8000 like so:
+
+```
+python -m SimpleHTTPServer
+```
+
+and visit [http://localhost:8000](http://localhost:8000) to run the game in the browser.
 
 
 ## Contributing

--- a/include/player.h
+++ b/include/player.h
@@ -14,8 +14,8 @@ public:
 	float distanceFromCursor();
 	bool jump();
 	void update(Ground& ground);
-	const char* getScore();
-	const char* getHighscore();
+	std::string getScore();
+	std::string getHighscore();
 	int getScoreInt();
 	int isDead();
 	void reset();

--- a/src/groundtile.cpp
+++ b/src/groundtile.cpp
@@ -1,6 +1,5 @@
 #include "groundtile.h"
 
-const int SCREEN_WIDTH = 800;
 const int SCREEN_HEIGHT = 480;
 
 GroundTile::GroundTile(SDL_Texture* p_tex, int p_index)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,10 +200,14 @@ void gameLoop()
 			window.render(ground.getTile(i));
 		}
 		window.render(25, 30, arrow);
-		window.render(62, 20, player.getScore(), font32_outline, black);
-		window.render(65, 23, player.getScore(), font32, white);
+
+		std::string distanceScore = player.getScore();
+		std::string highScore = player.getHighscore();
+
+		window.render(62, 20, distanceScore.c_str(), font32_outline, black);
+		window.render(65, 23, distanceScore.c_str(), font32, white);
 		window.render(0, 65, highscoreBox);
-		window.render(65, 64, player.getHighscore(), font16, white);
+		window.render(65, 64, highScore.c_str(), font16, white);
 
 		if (player.isDead() != ALIVE)
 		{

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <vector>
 #include <string>
+#include <iostream>
 
 #include "player.h"
 #include "entity.h"
@@ -11,7 +12,6 @@
 const float GRAVITY = 0.09f;
 const int SCREEN_WIDTH = 800;
 const int SCREEN_HEIGHT = 480;
-const int ALIVE = 0;
 const int CURSOR_DEATH = 1;
 const int HOLE_DEATH = 2;
 
@@ -138,18 +138,18 @@ void Player::update(Ground& ground)
 	
 }
 
-const char* Player::getScore()
+std::string Player::getScore()
 {
 	std::string s = std::to_string(score);
 	s = "DISTANCE: " + s;
-	return s.c_str();
+	return s;
 }
 
-const char* Player::getHighscore()
+std::string Player::getHighscore()
 {
 	std::string s = std::to_string(highscore);
 	s = "BEST: " + s;
-	return s.c_str();
+	return s;
 }
 
 int Player::getScoreInt()

--- a/src/renderwindow.cpp
+++ b/src/renderwindow.cpp
@@ -86,7 +86,7 @@ void RenderWindow::render(SDL_Texture* p_tex)
 
 void RenderWindow::render(float p_x, float p_y, const char* p_text, TTF_Font* font, SDL_Color textColor)
 {
-		SDL_Surface* surfaceMessage = TTF_RenderText_Blended( font, p_text, textColor);
+		SDL_Surface* surfaceMessage = TTF_RenderText_Blended(font, p_text, textColor);
 		SDL_Texture* message = SDL_CreateTextureFromSurface(renderer, surfaceMessage);
 
 		SDL_Rect src;


### PR DESCRIPTION
@PolyMarsDev this fixes the issue you describe in your video (which I was able to recreate on my local). It wasn't actually any issue with SDL_TTF lib, but with the fact that you were returning a ptr to your local variable which was allocated on the stack and not on the heap. Of course it was very strange that high score worked fine but distance didn't, but such is the way with memory in C/C++.

I also removed some stuff that triggered compiler warnings! Thanks for putting this example together :) I agree with people that the controls are borderline impossible (jumping while still pushing with your cursor without killing your guy is rough), but I still would like to see you finish this game someday! Cheers and thanks for the video!

Fix score functions returning local variables that become inaccessible
Remove unused variables triggering compiler warnings
Add .gitignore to keep emscripten-generated files out
Add emscripten compile to Makefile

