### PR TITLE
Fix a "fall under ground and live" bug

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -107,9 +107,14 @@ void Player::update(Ground& ground)
 	{
 		velocityX = 0;
 	}
-	setX(getX() + velocityX);
 
 	setY(getY() + velocityY);
+
+	//don't go into the ground if a an edge of a pit:
+	if (grounded || (getY() + getHeight()) < (SCREEN_HEIGHT - 64)) {
+		setX(getX() + velocityX);
+	}
+
 	if (ground.isTileBelow(getX(), getWidth()))
 	{
 		if (getY() + getHeight() < SCREEN_HEIGHT - 64)


### PR DESCRIPTION
Hi, saw your video on Youtube.
Love the game, especially how well it is made given the time constraints.

Found a small bug though: if you fall close to the right (far) edge of a pit, you don't die, because the check for ground collision is after the move.

So you keep falling (Y increases) but under ground, until a whole screen scrolls and then you die.